### PR TITLE
[RTL] Add dfflegalize syn step to convert to supported FFs

### DIFF
--- a/prga/renderer/templates/generic/synth.tmpl.tcl
+++ b/prga/renderer/templates/generic/synth.tmpl.tcl
@@ -63,6 +63,12 @@ techmap -map [file join $generic_script_root {{ entry.techmap }}]
 opt -full
 clean
 
+# print post-LUTmap report
+stat -width
+
+# convert unsupported FFs to supported FFs
+dfflegalize -cell \$_DFF_P_ x -cell \$_DFFE_PP_ x -cell \$_DFFE_PN_ x
+
 # print final report
 stat -width
 


### PR DESCRIPTION
As others have experienced  with upstream yosys (in https://github.com/PrincetonUniversity/prga/issues/13 and https://github.com/PrincetonUniversity/prga/issues/27), VTR complains when encountering an unsupported FF type. This can be resolved by inserting a dfflegalize pass at the end of the synthesis script to convert unsupported FF types (such as `$_SDFF_*_` or `$_DFFSRE_*_`) to supported types (`$_DFF_P_`, `$_DFFE_PN_`, `$_DFFE_PP_`).

With this, I am able to build and simulate the k4_N2_8x8 + bcd2bin example with upstream yosys (https://github.com/YosysHQ/yosys/commit/dac5bd1983a5078e3e7426df1e8ee48d300ead7d) and vtr (https://github.com/verilog-to-routing/vtr-verilog-to-routing/commit/f37ec16665d60a431b593fcdbcb29fb133b8f3dc).

I will need to do further regression testing with other examples, so I will leave this in draft state for now.